### PR TITLE
renamed go module to github.com/retinadata/crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
-module golang.org/x/crypto
+module github.com/retinadata/crypto
 
 go 1.17
 
+replace golang.org/x/crypto => github.com/retinadata/crypto v1.0.0-retina
+
 require (
+	golang.org/x/crypto v0.0.0-00010101000000-000000000000
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/retinadata/crypto v1.0.0-retina h1:HiblAQWxU2+75Z0rAGej+7Sd4niB57W3tzX76yPHWSM=
+github.com/retinadata/crypto v1.0.0-retina/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Cannot import the forked version. Trying to fix the following error by changing module name in go.mod file.

```
$  go mod download github.com/retinadata/crypto
go: github.com/retinadata/crypto@v1.0.0-retina: parsing go.mod:
        module declares its path as: golang.org/x/crypto
                but was required as: github.com/retinadata/crypto
```

